### PR TITLE
[front] #7 feat: フロント側の定数を一元管理する

### DIFF
--- a/src/main/front/src/AppbarComponent.tsx
+++ b/src/main/front/src/AppbarComponent.tsx
@@ -2,9 +2,10 @@ import * as React from "react";
 import { useState } from "react";
 import { AppBar, Toolbar, FormControl, Select, Avatar, MenuItem, IconButton, Popover, Typography, Box, Button } from '@material-ui/core';
 import moment from 'moment';
-import { AccountEdit, CellphoneSettingsVariant } from 'mdi-material-ui';
+import { CellphoneSettingsVariant } from 'mdi-material-ui';
 import logo from './static/images/logo.png';
 import avatarSample from './static/images/avatar_sample.png';
+import { Gorillana } from "./messageResource";
 
 moment.locale("ja");
 
@@ -13,6 +14,8 @@ const AppbarComponent = () => {
     const targetYearRange = [moment().subtract(1, 'year').year(), moment().year(), moment().add(1, 'year').year()];
     const [displayYear, setDisplayYear] = useState<string>(moment().year().toString());
     const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(null);
+    const sampleUserName = "山田太郎";
+    const sampleMailAddress = "taro.yamada@sample.com";
 
     const handleDisplayYear = (e: React.ChangeEvent<{value: unknown}>) => {
         setDisplayYear(e.target.value as string);
@@ -40,15 +43,15 @@ const AppbarComponent = () => {
                 <div style={{height: 180, width: 250}}>
                   <Avatar style={{width:60, height:60, margin: "0 auto"}} src={avatarSample}/>
                   <Typography component="div" style={{marginTop: 15, textAlign:"center"}}>
-                    <Box style={{color:"#616161"}} fontWeight="fontWeightBold" letterSpacing={1}>山田太郎</Box>
-                    <Box style={{color:"#9E9E9E", fontSize:14}}>administrator@sample.com</Box>
-                    <Button style={{marginTop: 10, width: 200, boxShadow:"none"}} variant="contained" color="secondary"><CellphoneSettingsVariant style={{marginRight: 5}}/>ユーザ設定</Button>
+                    <Box style={{color:"#616161"}} fontWeight="fontWeightBold" letterSpacing={1}>{sampleUserName}</Box>
+                    <Box style={{color:"#9E9E9E", fontSize:14}}>{sampleMailAddress}</Box>
+                    <Button style={{marginTop: 10, width: 200, boxShadow:"none"}} variant="contained" color="secondary"><CellphoneSettingsVariant style={{marginRight: 5}}/>{Gorillana.APPBAR.USER_SETTING}</Button>
                   </Typography>
                 </div>
                 <div style={{width:250, textAlign:"center"}}>
-                  <Button style={{margin: 10, width: 200}} variant="outlined">ログアウト</Button>
-                  <Button style={{fontSize:12}} variant="text">プライバシーポリシー</Button> / 
-                  <Button style={{fontSize:12}} variant="text">利用規約</Button>
+                  <Button style={{margin: 10, width: 200}} variant="outlined">{Gorillana.APPBAR.LOGOUT}</Button>
+                  <Button style={{fontSize:12}} variant="text">{Gorillana.APPBAR.PRIVACY_POLICY}</Button> / 
+                  <Button style={{fontSize:12}} variant="text">{Gorillana.APPBAR.TERM_OF_USE}</Button>
                 </div>
               </div>
           </Popover>
@@ -60,16 +63,16 @@ const AppbarComponent = () => {
             <AppBar position="static" style={{minHeight: "48px", backgroundColor:"#FFF", boxShadow: "none", borderBottom: "1px solid #E0E0E0"}}>
             <Toolbar style={{minHeight:"40px", display:"flex", flexDirection:"row", alignItems:"center", justifyContent:"space-between"}}>
               { Boolean(anchorEl) && showConfirmPopOver() }
-                  <img src={logo} width={120}></img>
+                  <img src={logo} width={120}/>
                 <div style={{display:"flex", alignItems:"center"}}>
                 <div style={{borderRight: "1px solid #E0E0E0", height:32, marginRight:16}}/>
                   <FormControl variant="outlined" style={{width:136}}>
                     <Select style={{margin: "0px 10px", height:40, color:"#9E9E9E"}} onChange={handleDisplayYear} value={displayYear}>
-                        {　targetYearRange.map(year => <MenuItem value={year.toString()}>{year.toString()}年度</MenuItem>)　}
+                        {　targetYearRange.map(year => <MenuItem value={year.toString()}>{year.toString()}{Gorillana.COMMON.FISCAL_YEAR}</MenuItem>)　}
                     </Select>
                   </FormControl>
                   <IconButton style={{padding:8}} onClick={(e) => handleClickAvatar(e)}><Avatar src={avatarSample}/></IconButton>
-                  <Typography variant="subtitle2" style={{maxWidth:80, color:"#9E9E9E", marginLeft:8, textOverflow:"ellipsis", overflow:"hidden", whiteSpace:"nowrap"}}>山田太郎</Typography>
+                  <Typography variant="subtitle2" style={{maxWidth:80, color:"#9E9E9E", marginLeft:8, textOverflow:"ellipsis", overflow:"hidden", whiteSpace:"nowrap"}}>{sampleUserName}</Typography>
                 </div>
             </Toolbar>
           </AppBar>

--- a/src/main/front/src/InputDialog.tsx
+++ b/src/main/front/src/InputDialog.tsx
@@ -10,6 +10,8 @@ import { StudentProperties, defaultStudent } from './const';
 import { Alphabetical, Numeric } from 'mdi-material-ui'
 import _ from 'lodash';
 import axios from 'axios';
+import { Gorillana } from './messageResource';
+import moment from 'moment';
 
 type StudentProps = {
     children: StudentProperties
@@ -17,10 +19,11 @@ type StudentProps = {
 
 
 const InputDialog: React.FC<StudentProps> = (props: StudentProps) => {
+    const targetYearRange = [moment().subtract(1, 'year').year(), moment().year(), moment().add(1, 'year').year()];
     const { state, dispatch } = useContext(Store);
     const [editTargetStudent, setTargetStudent] = useState<StudentProperties>(props.children);
 
-    const dialogMode = (props.children.studentId > 0) ? "編集" : "新規作成";
+    const dialogMode = (props.children.studentId > 0) ? Gorillana.STUDENT.EDIT : Gorillana.STUDENT.CREATE;
 
     const handleTargetStudent = (event: React.ChangeEvent<{value: unknown}>, property: keyof StudentProperties) => {
         // 念のためコピーに対して更新を実施した後でstateに反映
@@ -37,7 +40,7 @@ const InputDialog: React.FC<StudentProps> = (props: StudentProps) => {
                 updateTargetStudent[property] = event.target.value as number ;
                 break;
             default: 
-                new Error("予期せぬエラー");
+                new Error(`${Gorillana.ERROR.UNEXPECTED}`);
                 break;
         }
         setTargetStudent(updateTargetStudent);
@@ -70,15 +73,15 @@ const InputDialog: React.FC<StudentProps> = (props: StudentProps) => {
     return (
         <div>
             <Dialog open={true}>
-                <DialogTitle>学生の{dialogMode}</DialogTitle>
+                <DialogTitle>{dialogMode}</DialogTitle>
                     <DialogContent>
                     <DialogContentText style={{width:400, padding:10}}>
-                        <TextField disabled={true} value={dialogMode === "編集" ? props.children.studentId : ""} placeholder={dialogMode === "新規作成" ? "自動で入力されます" : ""} style={{marginBottom:24, width:"100%"}} label="管理ID" variant="outlined" InputProps={{startAdornment:(<InputAdornment position="start"><Numeric color="action"/> : </InputAdornment>)}}/>
+                        <TextField disabled={true} value={dialogMode === Gorillana.STUDENT.EDIT ? props.children.studentId : ""} placeholder={dialogMode === Gorillana.STUDENT.CREATE ? Gorillana.COMMON.AUTO_INPUT : ""} style={{marginBottom:24, width:"100%"}} label={Gorillana.STUDENT.STUDENT_ID} variant="outlined" InputProps={{startAdornment:(<InputAdornment position="start"><Numeric color="action"/> : </InputAdornment>)}}/>
                         <TextField 
                             value={editTargetStudent.studentNumber} 
                             onChange={(e) => handleTargetStudent(e, "studentNumber")} 
                             style={{marginBottom:24, width:"100%"}} 
-                            label="学籍番号" 
+                            label={Gorillana.STUDENT.STUDENT_NUMBER} 
                             variant="outlined" 
                             InputProps={{startAdornment:(<InputAdornment position="start"><Alphabetical color="action"/> : </InputAdornment>)}}
                         />
@@ -86,7 +89,7 @@ const InputDialog: React.FC<StudentProps> = (props: StudentProps) => {
                             value={editTargetStudent.lastName} 
                             onChange={(e) => handleTargetStudent(e, "lastName")} 
                             style={{marginBottom:24, width:"100%"}} 
-                            label="姓" 
+                            label={Gorillana.STUDENT.LAST_NAME}
                             variant="outlined" 
                             InputProps={{startAdornment:(<InputAdornment position="start"><Alphabetical color="action"/> : </InputAdornment>)}}
                         />
@@ -94,26 +97,24 @@ const InputDialog: React.FC<StudentProps> = (props: StudentProps) => {
                             value={editTargetStudent.firstName} 
                             onChange={(e) => handleTargetStudent(e, "firstName")} 
                             style={{marginBottom:24, width:"100%"}} 
-                            label="名" 
+                            label={Gorillana.STUDENT.FIRST_NAME}
                             variant="outlined" 
                             InputProps={{startAdornment:(<InputAdornment position="start"><Alphabetical color="action"/> : </InputAdornment>)}}
                             />                        
                         <FormControl style={{marginBottom:24, width:"100%"}} variant="outlined">
-                            <InputLabel variant="outlined">学部</InputLabel>
+                            <InputLabel variant="outlined">{Gorillana.STUDENT.FACULITY_NAME}</InputLabel>
                                 <Select labelWidth={32} value={editTargetStudent.faculityId} onChange={(e) => handleTargetStudent(e, "faculityId")}>
-                                    <MenuItem value={0}>未選択</MenuItem>
+                                    <MenuItem value={0}>{Gorillana.COMMON.NOT_SELCET}</MenuItem>
                                     <MenuItem value={1}>工学①</MenuItem>
                                     <MenuItem value={2}>理学②</MenuItem>
                                     <MenuItem value={3}>文学⑨</MenuItem>
                                 </Select>
                         </FormControl>
                         <FormControl style={{marginBottom:24, width:"100%"}} variant="outlined">
-                            <InputLabel variant="outlined">入学年度</InputLabel>
+                            <InputLabel variant="outlined">{Gorillana.STUDENT.ENTRANCE_YEAR}</InputLabel>
                                 <Select labelWidth={64} value={editTargetStudent.entranceYear} onChange={(e) => handleTargetStudent(e, "entranceYear")}>
-                                    <MenuItem value={0}>未選択</MenuItem>
-                                    <MenuItem value={"2018"}>2018年度</MenuItem>
-                                    <MenuItem value={"2019"}>2019年度</MenuItem>
-                                    <MenuItem value={"2020"}>2020年度</MenuItem>
+                                    <MenuItem value={0}>{Gorillana.COMMON.NOT_SELCET}</MenuItem>
+                                    { targetYearRange.map(year => <MenuItem value={year.toString()}>{year + Gorillana.COMMON.FISCAL_YEAR}</MenuItem>) }
                                 </Select>
                         </FormControl>
                     </DialogContentText>
@@ -123,8 +124,8 @@ const InputDialog: React.FC<StudentProps> = (props: StudentProps) => {
                         dispatch({type: ActionType.DIALOG_UPDATE, payload:{...state, isShowDialog: false}})
                         setTargetStudent(defaultStudent);
                     }}
-                    >キャンセル</Button>
-                    <Button onClick={() => { dialogMode === "新規作成" ? postStudent() : putStudent(); dispatch({type: ActionType.DIALOG_UPDATE, payload:{...state, isShowDialog: false}})}} color="secondary">登録</Button>
+                    >{Gorillana.COMMON.CANCEL}</Button>
+                    <Button onClick={() => { dialogMode === Gorillana.STUDENT.CREATE ? postStudent() : putStudent(); dispatch({type: ActionType.DIALOG_UPDATE, payload:{...state, isShowDialog: false}})}} color="secondary">{Gorillana.STUDENT.CREATE}</Button>
                 </DialogActions>
             </Dialog>
         </div>

--- a/src/main/front/src/StudentManagement.tsx
+++ b/src/main/front/src/StudentManagement.tsx
@@ -1,12 +1,9 @@
 import * as React from 'react';
-import { useContext, useState, useEffect } from 'react';
+import { useContext, useEffect } from 'react';
 import { Store } from './store';
 import { ActionType } from './reducer';
-import { StudentProperties, defaultStudent } from './const';
-import { Button } from '@material-ui/core';
-import { InsertDriveFileTwoTone, PersonAddTwoTone } from '@material-ui/icons';
+import { StudentProperties } from './const';
 import TableComponent from './TableComponent';
-import InputDialog from './InputDialog';
 import axios from 'axios';
 
 axios.defaults.headers.post["Content-Type"] = "application/x-www-form-urlencoded";
@@ -14,6 +11,7 @@ axios.defaults.headers.post["Content-Type"] = "application/x-www-form-urlencoded
 const StudentManagement = () => {
     const { state, dispatch } = useContext(Store);
 
+    // TODO この使い方はよろしくないらしい
     useEffect(() => {
         getStudents();
     },[]);

--- a/src/main/front/src/TabComponent.tsx
+++ b/src/main/front/src/TabComponent.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Tabs, Tab, Grid, Tooltip } from '@material-ui/core'
 import { InsertChartTwoTone, SupervisedUserCircleTwoTone, TodayTwoTone, SettingsApplicationsTwoTone } from '@material-ui/icons';
 import StudentManagement from './StudentManagement';
+import { Gorillana } from './messageResource';
 
 const tooltipEntryDelay = 200;
 
@@ -16,10 +17,10 @@ const TabComponent: React.FC = () => {
                 <Grid style={{minHeight: "100vh", borderRight: "1px solid #E0E0E0"}} item>
                 <Tabs orientation="vertical" value={tabId} onChange={handleTabs}>
                     // TODO アイコンの横にラベルを出したいけど、Material-UIのcssに手を入れる必要があるので一旦放置
-                    <Tooltip title="学習を分析する" enterDelay={tooltipEntryDelay}><Tab icon={<InsertChartTwoTone/>}/></Tooltip>
-                    <Tooltip title="学生を管理する" enterDelay={tooltipEntryDelay}><Tab icon={<SupervisedUserCircleTwoTone/>}/></Tooltip>
-                    <Tooltip title="スケジュールを管理する" enterDelay={tooltipEntryDelay}><Tab icon={<TodayTwoTone/>}/></Tooltip>
-                    <Tooltip title="設定を変更する" enterDelay={tooltipEntryDelay}><Tab icon={<SettingsApplicationsTwoTone/>}/></Tooltip>
+                    <Tooltip title={Gorillana.TAB_MENU.ANALYZE_STUDENT} enterDelay={tooltipEntryDelay}><Tab icon={<InsertChartTwoTone/>}/></Tooltip>
+                    <Tooltip title={Gorillana.TAB_MENU.MANAGE_STUDENT} enterDelay={tooltipEntryDelay}><Tab icon={<SupervisedUserCircleTwoTone/>}/></Tooltip>
+                    <Tooltip title={Gorillana.TAB_MENU.MANAGE_SCHEDULE} enterDelay={tooltipEntryDelay}><Tab icon={<TodayTwoTone/>}/></Tooltip>
+                    <Tooltip title={Gorillana.TAB_MENU.CHANGE_SETTING} enterDelay={tooltipEntryDelay}><Tab icon={<SettingsApplicationsTwoTone/>}/></Tooltip>
                 </Tabs>
                 </Grid>
                 <Grid style={{minHeight: "100vh", backgroundColor:"#FAFAFA"}} item xs>

--- a/src/main/front/src/TableComponent.tsx
+++ b/src/main/front/src/TableComponent.tsx
@@ -2,13 +2,14 @@ import * as React from 'react';
 import { useContext } from 'react';
 import { Store } from './store';
 import { ActionType } from './reducer';
-import { Table, TableHead, TableRow, TableCell, TableBody, Button, Paper, Tooltip, Popover, Typography, Snackbar } from '@material-ui/core';
-import { EditTwoTone, DeleteTwoTone, PersonAddTwoTone, InsertDriveFileTwoTone } from '@material-ui/icons';
+import { Table, TableHead, TableRow, TableCell, TableBody, Button, Paper, Tooltip, Popover, Typography } from '@material-ui/core';
+import { EditTwoTone, DeleteTwoTone } from '@material-ui/icons';
 import { TrashCanOutline, AccountPlus, FileMove } from 'mdi-material-ui';
 import { StudentProperties, defaultStudent } from './const';
 import InputDialog from './InputDialog';
 import axios from 'axios';
 import _ from 'lodash';
+import { Gorillana } from './messageResource';
 
 type StudentProps = {
     children: StudentProperties[]
@@ -19,8 +20,18 @@ const TableComponent: React.FC<StudentProps> = (props: StudentProps) => {
     const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(null);
     const [targetStudent, setTargetStudent] = React.useState<StudentProperties>(defaultStudent);
    
-    const headerElements = ["管理ID", "学籍番号", "姓", "名", "学部", "クラス", "入学年度", "", ""];
-    
+    const headerElements = [
+        Gorillana.STUDENT.STUDENT_ID, 
+        Gorillana.STUDENT.STUDENT_NUMBER, 
+        Gorillana.STUDENT.LAST_NAME, 
+        Gorillana.STUDENT.FIRST_NAME, 
+        Gorillana.STUDENT.FACULITY_NAME, 
+        Gorillana.STUDENT.CLASS, 
+        Gorillana.STUDENT.ENTRANCE_YEAR, 
+        "", 
+        ""
+    ]
+
     const students = state.students;
 
     const handleClickDelete = (event: React.MouseEvent<HTMLButtonElement>, row: StudentProperties) => {
@@ -55,11 +66,11 @@ const TableComponent: React.FC<StudentProps> = (props: StudentProps) => {
             }}>
                 <div style={{margin:15, display:"flex", alignItems:"center"}}>
                     <TrashCanOutline color="secondary"/>
-                    <Typography style={{fontWeight:"bold", marginLeft:5, fontSize:14}}>本当に削除しますか？</Typography>
+        <Typography style={{fontWeight:"bold", marginLeft:5, fontSize:14}}>{Gorillana.COMMON.CONFIRM_DELETE}</Typography>
                 </div>
                 <div style={{display:"flex", margin:10, flexDirection:"row-reverse"}}>
-                    <Button size="small" onClick={deleteStudent} color="secondary">OK</Button>
-                    <Button size="small" onClick={() => setAnchorEl(null)}>キャンセル</Button>
+        <Button size="small" onClick={deleteStudent} color="secondary">{Gorillana.COMMON.OK}</Button>
+                    <Button size="small" onClick={() => setAnchorEl(null)}>{Gorillana.COMMON.CANCEL}</Button>
                 </div>
             </Popover>
         );
@@ -68,8 +79,8 @@ const TableComponent: React.FC<StudentProps> = (props: StudentProps) => {
     return (
         <div>
             <div style={{textAlign:"center", margin:"15px 0px"}}>
-                <Button style={{margin:"5px 5px", boxShadow:"none"}} variant="contained" color="secondary" startIcon={<AccountPlus/>} onClick={() => { setTargetStudent(defaultStudent);dispatch({type: ActionType.DIALOG_UPDATE, payload:{...state, isShowDialog: true}})}}>新規作成</Button>
-                <Button style={{margin:"5px 5px", backgroundColor:"#FFFFFF"}} variant="outlined" startIcon={<FileMove/>}>CSVから新規作成</Button>
+                <Button style={{margin:"5px 5px", boxShadow:"none"}} variant="contained" color="secondary" startIcon={<AccountPlus/>} onClick={() => { setTargetStudent(defaultStudent);dispatch({type: ActionType.DIALOG_UPDATE, payload:{...state, isShowDialog: true}})}}>{Gorillana.STUDENT.CREATE}</Button>
+    <Button style={{margin:"5px 5px", backgroundColor:"#FFFFFF"}} variant="outlined" startIcon={<FileMove/>}>{Gorillana.STUDENT.CREATE_FROM_CSV}</Button>
             </div>
             <Paper style={{width:"90%", margin:"0 auto"}}>
                 { Boolean(anchorEl) && showConfirmPopOver() }
@@ -87,8 +98,8 @@ const TableComponent: React.FC<StudentProps> = (props: StudentProps) => {
                                     return (
                                         <TableRow>
                                             {_.map(row).map(cell => <TableCell style={{textAlign:"center"}}>{cell}</TableCell>)}
-                                            <Tooltip title="学生を編集する"><TableCell style={{textAlign:"center"}}><Button onClick={(e) => {setTargetStudent(row);dispatch({type: ActionType.DIALOG_UPDATE, payload:{...state, isShowDialog: true}})}}><EditTwoTone/></Button></TableCell></Tooltip>
-                                            <Tooltip title="学生を削除する"><TableCell style={{textAlign:"center"}}><Button onClick={(e) => handleClickDelete(e, row)}><DeleteTwoTone/></Button></TableCell></Tooltip>
+                                            <Tooltip title={Gorillana.STUDENT.EDIT}><TableCell style={{textAlign:"center"}}><Button onClick={(e) => {setTargetStudent(row);dispatch({type: ActionType.DIALOG_UPDATE, payload:{...state, isShowDialog: true}})}}><EditTwoTone/></Button></TableCell></Tooltip>
+                                            <Tooltip title={Gorillana.STUDENT.DELETE}><TableCell style={{textAlign:"center"}}><Button onClick={(e) => handleClickDelete(e, row)}><DeleteTwoTone/></Button></TableCell></Tooltip>
                                         </TableRow>
                                     )
                                 })

--- a/src/main/front/src/messageResource.ts
+++ b/src/main/front/src/messageResource.ts
@@ -1,0 +1,39 @@
+export const Gorillana = {
+    APPBAR: {
+        USER_SETTING: "ユーザ設定",
+        LOGOUT: "ログアウト",
+        PRIVACY_POLICY: "プライバシーポリシー",
+        TERM_OF_USE: "利用規約"
+    },
+    COMMON: {
+        CANCEL: "キャンセル",
+        OK: "OK",
+        CONFIRM_DELETE: "本当に削除しますか？",
+        AUTO_INPUT: "自動で入力されます",
+        NOT_SELCET: "未選択",
+        FISCAL_YEAR: "年度"
+    },
+    TAB_MENU: {
+        ANALYZE_STUDENT: "学習を分析する",
+        MANAGE_STUDENT: "学生を管理する",
+        MANAGE_SCHEDULE: "スケジュールを管理する",
+        CHANGE_SETTING: "設定を変更する"
+    },
+    STUDENT: {
+        CREATE: "学生の登録",
+        EDIT: "学生の編集",
+        DELETE: "学生の削除",
+        CREATE_FROM_CSV: "CSVから登録",
+        STUDENT_ID: "管理ID",
+        STUDENT_NUMBER: "学籍番号",
+        LAST_NAME: "姓",
+        FIRST_NAME: "名",
+        FACULITY_NAME: "学部",
+        CLASS: "クラス",
+        ENTRANCE_YEAR: "入学年度"
+    },
+    ERROR: {
+        UNEXPECTED: "予期せぬエラー",
+        INVALID_STATUS: "不正な状態です"
+    }
+}

--- a/src/main/front/src/reducer.ts
+++ b/src/main/front/src/reducer.ts
@@ -1,4 +1,5 @@
 import { IStore } from './store';
+import { Gorillana } from './messageResource';
 
 export enum ActionType {
     "DIALOG_UPDATE",
@@ -14,6 +15,6 @@ export const reducer: React.Reducer<IStore, IAction> = (state, action: IAction) 
     switch(action.type) {
         case ActionType.DIALOG_UPDATE: return { ...state, isShowDialog: action.payload.isShowDialog }
         case ActionType.STUDENT_UPDATE: return { ...state, students: action.payload.students }
-        default: throw new Error("不正な状態です");
+        default: throw new Error(`${Gorillana.ERROR.INVALID_STATUS}`);
     }
 };


### PR DESCRIPTION
### 概要
 `messageResource.ts`でフロント側で利用される定数を一括管理できるようにしてみた（たたき台）

namespaceを使う方法は[非推奨](https://michelenasti.com/2019/01/23/is-typescript-namespace-feature-deprecated.html)みたいな話題もあったので、constを使って作った。

運用に関するご意見はどしどし募集中です。
※ リソースの切り分けは仮実装なので、うまい分け方があればぜひ

### 使い方
:one: **新しく定数を作る**  
`messageResource.ts`に自由に定義する

```typescript
export const Gorillana = {
  // この中であれば自由に定義OK
  SAMPLE: {
    FIRST: "最初のサンプル"
  }
}
```

:two: **定義した定数を使う**  
`messageResource.ts`をインポートして、使いたい定数までのパスをかく

```typescript
import { Gorillana } from './messageResource';  
// 中略
return (
  <div>
    // ボタン要素に「最初のサンプル」と表示されるようにする
    <Button variant="outlined" color="primary">{Gorillana.SAMPLE.FIRST}</Button>
  </div>
)
```